### PR TITLE
Markdown link need explicitly to set http

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ More documentation coming soon.
   - Organization: <http://cloudfoundry.slack.com>
   - Channel: `#persi`
 - Contact: [EMC Dojo](mailto:emcdojo@emc.com) [@EMCDojo](https://twitter.com/hashtag/emcdojo)
-- Blog: [EMC Dojo Blog](dojoblog.emc.com)
+- Blog: [EMC Dojo Blog](http://dojoblog.emc.com)


### PR DESCRIPTION
Currently it is reporting page can't be found 404 error when click EMC
Dojo Blog link
